### PR TITLE
added code to share a query

### DIFF
--- a/app/api/QueryAPI.js
+++ b/app/api/QueryAPI.js
@@ -126,4 +126,33 @@ export default class QueryAPI {
     xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
     xhr.send();
   };
+
+  static query_operation = (queryId, userId, projectId, operation, callback) => {
+    let url = _config.QUERY_API_BASE + "/";
+    url += userId + "/";
+    url += "projects/" + projectId + "/";
+    url += "queries/";
+    url += encodeURIComponent(queryId) + "/";
+    url += operation;
+    const xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function () {
+      if (xhr.readyState === XMLHttpRequest.DONE) {
+        if (xhr.status === 200) {
+          const respData = JSON.parse(xhr.responseText);
+          if (!respData) {
+            callback(null);
+          } else if (respData.error) {
+            callback(new APIError(respData.error));
+          } else {
+            callback(respData);
+          }
+        } else {
+          callback(null);
+        }
+      }
+    };
+    xhr.open("GET", url);
+    xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+    xhr.send({});
+  };  
 }

--- a/app/util/FlexRouter.js
+++ b/app/util/FlexRouter.js
@@ -3,11 +3,18 @@ Check this out later: https://zhirzh.github.io/2017/01/30/browser-history-functi
 */
 
 export default class FlexRouter {
-  static gotoSingleSearch = (queryId) => {
+  static createSearchQueryUrl = (queryId) => {
     let url = FlexRouter.__getBaseUrl() + "/tool/single-search";
     if (queryId) {
       url += "?queryId=" + queryId;
     }
+    return url;
+  };
+
+  static gotoSingleSearch = (queryId) => {
+    let url = FlexRouter.createSearchQueryUrl(queryId);
+    console.log("returned url");
+    console.log(url);
     document.location.href = url;
   };
 

--- a/app/util/QueryUtil.jsx
+++ b/app/util/QueryUtil.jsx
@@ -19,4 +19,12 @@ export default class QueryUtil {
       });
     });
   };
+
+  static shareQuery = (query, userId, projectId, callback) => {
+    if (!query || !userId || !projectId) return null;
+
+    QueryAPI.query_operation(query.id, userId, projectId, "share", (status) => {
+        callback(status)
+      });
+  };  
 }

--- a/app/workspace/projects/query/ProjectQueriesTable.jsx
+++ b/app/workspace/projects/query/ProjectQueriesTable.jsx
@@ -157,6 +157,43 @@ class ProjectQueriesTable extends React.PureComponent {
     );
   };
 
+
+  shareQuery = (namedQuery) => {
+    const msg =
+        "Are you sure you want to share query: " +
+        namedQuery.name +
+          "?\n" + 
+          "\nSharing copies a link to the clipboard. Other users can click on the link and see" +
+          " the results of the shared query on the Search page. They cannot edit the query." + 
+          "\nIf you delete the query, the link will stop working." + 
+          "\nUsers can save a copy of the query in their own workspace.";
+    if (ComponentUtil.userConfirm(msg)) {
+      this.shareProjectQuery(
+        this.props.user.id,
+        this.props.project,
+        namedQuery
+      );
+    }
+  };
+
+
+  shareProjectQuery = (userId, project, queryToShare) => {
+    QueryUtil.shareQuery(
+      queryToShare,
+      userId,
+      project.id,
+      (queryShared) => {
+        if (queryShared) {
+          let queryUrl = FlexRouter.createSearchQueryUrl(queryToShare.id);
+          navigator.clipboard.writeText(queryUrl);
+          alert("Query link has been copied to the clipboard");
+        }
+        else {
+          alert("An error occurred while sharing this query");
+        }
+      }
+    );
+  };
   onSelectQuery = (item) => this.setState({ selectedQueries: item });
 
   sortQueries = (queries, sort) =>
@@ -213,6 +250,7 @@ class ProjectQueriesTable extends React.PureComponent {
             { field: "query", content: "Query", sortable: true },
             { field: "", content: "", sortable: false },
             { field: "", content: "", sortable: false },
+            { field: "", content: "", sortable: false },
           ]}
           row={(namedQuery) => [
             //must be a proper named query (Project.queries)
@@ -248,6 +286,18 @@ class ProjectQueriesTable extends React.PureComponent {
                   <span className="bg__searchTerm">
                     {namedQuery.query.toHumanReadableString()}
                   </span>
+                </div>
+              ),
+            },
+            {
+              content: (
+                <div>
+                  <a
+                    className="btn blank warning"
+                    onClick={() => this.shareQuery(namedQuery)}
+                  >
+                    Share
+                  </a>
                 </div>
               ),
             },


### PR DESCRIPTION
Closes [#879](https://github.com/beeldengeluid/labo-components/issues/879)

Test plan:
- [ ] Checkout this branch of labo-workspace-components, the share-query branch of labs-user-space-api and the 879-share-query branch of clariah-mediasuite
- [ ] Run the Media Suite locally with a local userspace API  **or shall we deploy to test for review?**
- [ ] Create a query and save it to your workspace
- [ ] Click on the Share button for the query. 
- [ ] Log out of the Media Suite
- [ ] Paste the link from the clipboard (do NOT log in to the Media Suite when doing this)
- [ ] Check that you can now view your query